### PR TITLE
Implements tracer for sip messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
 [[package]]
 name = "libsip"
 version = "0.2.6"
+source = "git+https://github.com/vasilakisfil/libsip?branch=feat/quoted-string#507551cc9914b566dab91592ce495c278e9b0d0c"
 dependencies = [
  "md5",
  "nom",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,8 +12,7 @@ futures-util = "0.3.4"
 chrono = { version = "0.4.11", features = ["serde"] }
 log = { version = "0.4.8" }
 pretty_env_logger = { version = "0.4.0" }
-libsip = { path = "../../libsip" }
-#libsip = { git = "https://github.com/vasilakisfil/libsip", branch = "tmp/contact-params-fix" }
+libsip = { git = "https://github.com/vasilakisfil/libsip", branch = "feat/quoted-string" }
 nom = { version = "6.0.0-alpha1" }
 rand = { version = "0.7" }
 rand_chacha = { version = "0.2.2" }

--- a/lib/models/src/lib.rs
+++ b/lib/models/src/lib.rs
@@ -1,24 +1,42 @@
 macro_rules! header {
-    ($iter:expr, $header:path) => {
-        $iter.find_map(|header| {
-            if let $header(header) = header {
-                Some(header)
-            } else {
-                None
-            }
-        })
+    ($iter:expr, $header:path, $error:expr) => {
+        $iter
+            .find_map(|header| {
+                if let $header(header) = header {
+                    Some(header)
+                } else {
+                    None
+                }
+            })
+            .ok_or($error)
     };
 }
 
 macro_rules! named_header_param {
-    ($header:expr, $param:expr) => {
-        $header.and_then(|header| {
-            if let Some(param) = header.parameters.get($param) {
-                param.as_ref()
+    ($header:expr, $param:expr, $error:expr) => {
+        if let Ok(header) = $header {
+            if let Some(Some(param)) = header.parameters.get($param) {
+                Ok(param)
             } else {
-                None
+                Err($error)
             }
-        })
+        } else {
+            Err($error)
+        }
+    };
+}
+
+macro_rules! named_header_username {
+    ($header:expr, $error:expr) => {
+        if let Ok(header) = $header {
+            if let Some(auth) = &header.uri.auth {
+                Ok(&auth.username)
+            } else {
+                Err($error)
+            }
+        } else {
+            Err($error)
+        }
     };
 }
 

--- a/lib/models/src/not_found.rs
+++ b/lib/models/src/not_found.rs
@@ -37,7 +37,7 @@ fn create_final_response_from(request: crate::Request) -> Response {
     headers.push(Header::CallId(
         request.call_id().expect("request CallId header").clone(),
     ));
-    let cseq = request.cseq().expect("request CallId header").clone();
+    let cseq = request.cseq().expect("request CallId header");
     headers.push(Header::CSeq(cseq.0, cseq.1));
     headers.push(Header::ContentLength(0));
     headers.push(Header::Server("viska".into()));
@@ -45,7 +45,7 @@ fn create_final_response_from(request: crate::Request) -> Response {
     Response {
         code: 404,
         version: Default::default(),
-        headers: headers,
+        headers,
         body: vec![],
     }
 }

--- a/lib/models/src/transaction.rs
+++ b/lib/models/src/transaction.rs
@@ -51,7 +51,7 @@ fn create_final_response_from(request: crate::Request) -> Response {
     headers.push(Header::CallId(
         request.call_id().expect("request CallId header").clone(),
     ));
-    let cseq = request.cseq().expect("request CallId header").clone();
+    let cseq = request.cseq().expect("request CallId header");
     headers.push(Header::CSeq(cseq.0, cseq.1));
     let mut contact = request
         .contact_header()
@@ -65,7 +65,7 @@ fn create_final_response_from(request: crate::Request) -> Response {
     Response {
         code: 200,
         version: Default::default(),
-        headers: headers,
+        headers,
         body: vec![],
     }
 }

--- a/lib/server/src/udp.rs
+++ b/lib/server/src/udp.rs
@@ -1,12 +1,8 @@
 use common::bytes::Bytes;
 use common::futures::SinkExt;
 use common::futures_util::stream::StreamExt;
-use common::libsip;
-//use common::log::debug;
-use common::nom::error::VerboseError;
 use common::tokio_util::codec::BytesCodec;
 use common::tokio_util::udp::UdpFramed;
-//use helpers::pretty_print;
 use tokio::net::UdpSocket;
 
 pub async fn start() {
@@ -20,7 +16,7 @@ pub async fn start() {
     while let Some(request) = stream.next().await {
         match request {
             Ok((request, addr)) => {
-                let response = process_request(request).await;
+                let response = processor::process_message(request).await;
                 common::log::info!("{}", addr);
                 match response {
                     Ok(response) => sink
@@ -33,43 +29,4 @@ pub async fn start() {
             Err(e) => common::log::error!("{:?}", e),
         }
     }
-}
-/*
-async fn foo() -> Vec<u8> {
-    use tokio::prelude::*; // for read_to_end()
-
-    let mut file = File::open("logs/response.sip")
-        .await
-        .expect("response file");
-    let mut contents = vec![];
-    file.read_to_end(&mut contents).await.expect("read file");
-
-    contents
-}*/
-
-async fn process_request(request: common::bytes::BytesMut) -> Result<Vec<u8>, String> {
-    use std::fs::OpenOptions;
-    use std::io::prelude::*;
-
-    let mut file = OpenOptions::new()
-        .write(true)
-        .append(true)
-        .open("my-file")
-        .unwrap();
-    writeln!(
-        file,
-        "{}",
-        String::from_utf8(request.to_vec()).expect("bytes to string")
-    )
-    .expect("write to file");
-    //debug!("{}", pretty_print(request.to_vec()));
-
-    let (_, request) = libsip::parse_message::<VerboseError<&[u8]>>(&request.to_vec())
-        .map_err(|e| e.to_string())?;
-    let response = processor::get_response(request).await?;
-    writeln!(file, "{}", response.clone()).expect("write to file");
-    let response = format!("{}", response).into_bytes();
-    //debug!("{}", pretty_print(response.clone()));
-
-    Ok(response)
 }

--- a/lib/store/src/dialog.rs
+++ b/lib/store/src/dialog.rs
@@ -89,7 +89,7 @@ impl LazyQuery {
     }
 
     pub async fn load(self) -> Result<Vec<Dialog>, Error> {
-        Ok(self.query.get_results(&db_conn()?)?.into())
+        Ok(self.query.get_results(&db_conn()?)?)
     }
 
     pub async fn first(self) -> Result<Dialog, Error> {

--- a/lib/store/src/lib.rs
+++ b/lib/store/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 pub extern crate diesel;
+mod schema;
 
 use diesel::pg::PgConnection;
 use diesel::r2d2::{ConnectionManager, Pool};
@@ -8,13 +9,16 @@ use std::sync::Arc;
 
 mod dialog;
 mod error;
-pub mod schema;
+mod request;
+mod response;
 mod transaction;
 
 pub use dialog::{
     Dialog, DialogFlow, DialogWithTransaction, DirtyDialog, DirtyDialogWithTransaction,
 };
 pub use error::Error;
+pub use request::{DirtyRequest, Request};
+pub use response::{DirtyResponse, Response};
 pub use transaction::{DirtyTransaction, Transaction, TransactionState};
 
 type DbConn =

--- a/lib/store/src/request.rs
+++ b/lib/store/src/request.rs
@@ -1,0 +1,87 @@
+use crate::schema::requests;
+use crate::{db_conn, Error};
+use common::chrono::{DateTime, Utc};
+use diesel::prelude::*;
+
+#[derive(Queryable, AsChangeset, Insertable, Debug, Clone)]
+#[table_name = "requests"]
+pub struct Request {
+    pub id: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub method: String,
+    pub uri: String,
+    pub headers: String,
+    pub body: Option<String>,
+    pub raw_message: Option<String>,
+}
+
+#[derive(AsChangeset, Insertable, Debug, Default)]
+#[table_name = "requests"]
+pub struct DirtyRequest {
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub method: Option<String>,
+    pub uri: Option<String>,
+    pub headers: Option<String>,
+    pub body: Option<String>,
+    pub raw_message: Option<String>,
+}
+
+pub struct LazyQuery {
+    query: requests::BoxedQuery<'static, diesel::pg::Pg>,
+}
+
+impl LazyQuery {
+    pub fn new(query: requests::BoxedQuery<'static, diesel::pg::Pg>) -> Self {
+        Self { query }
+    }
+
+    pub fn paginate(mut self, page: i64, per_page: i64) -> Self {
+        let offset = (page - 1) * per_page;
+
+        self.query = self.query.offset(offset).limit(per_page);
+        self
+    }
+
+    pub fn order_by_created_at(mut self) -> Self {
+        self.query = self.query.order(requests::created_at.desc());
+        self
+    }
+
+    pub async fn load(self) -> Result<Vec<Request>, Error> {
+        Ok(self.query.get_results(&db_conn()?)?)
+    }
+
+    pub async fn first(self) -> Result<Request, Error> {
+        Ok(self.query.first(&db_conn()?)?)
+    }
+}
+
+impl Request {
+    pub fn query() -> LazyQuery {
+        LazyQuery::new(requests::table.into_boxed())
+    }
+
+    pub async fn find(id: i64) -> Result<Self, Error> {
+        Ok(requests::table.find(id).first::<Self>(&db_conn()?)?)
+    }
+
+    pub async fn create(record: DirtyRequest) -> Result<Self, Error> {
+        use diesel::insert_into;
+
+        Ok(insert_into(requests::table)
+            .values(record)
+            .get_result(&db_conn()?)?)
+    }
+
+    pub async fn update(record: DirtyRequest, id: i64) -> Result<Self, Error> {
+        Ok(diesel::update(requests::table.filter(requests::id.eq(id)))
+            .set(&record)
+            .get_result(&db_conn()?)?)
+    }
+
+    pub async fn delete(id: i64) -> Result<Self, Error> {
+        Ok(diesel::delete(requests::table.filter(requests::id.eq(id))).get_result(&db_conn()?)?)
+    }
+}

--- a/lib/store/src/response.rs
+++ b/lib/store/src/response.rs
@@ -1,0 +1,87 @@
+use crate::schema::responses;
+use crate::{db_conn, Error};
+use common::chrono::{DateTime, Utc};
+use diesel::prelude::*;
+
+#[derive(Queryable, AsChangeset, Insertable, Debug, Clone)]
+#[table_name = "responses"]
+pub struct Response {
+    pub id: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub code: i16,
+    pub headers: String,
+    pub body: Option<String>,
+    pub raw_message: Option<String>,
+}
+
+#[derive(AsChangeset, Insertable, Debug, Default)]
+#[table_name = "responses"]
+pub struct DirtyResponse {
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub code: Option<i16>,
+    pub headers: Option<String>,
+    pub body: Option<String>,
+    pub raw_message: Option<String>,
+}
+
+pub struct LazyQuery {
+    query: responses::BoxedQuery<'static, diesel::pg::Pg>,
+}
+
+impl LazyQuery {
+    pub fn new(query: responses::BoxedQuery<'static, diesel::pg::Pg>) -> Self {
+        Self { query }
+    }
+
+    pub fn paginate(mut self, page: i64, per_page: i64) -> Self {
+        let offset = (page - 1) * per_page;
+
+        self.query = self.query.offset(offset).limit(per_page);
+        self
+    }
+
+    pub fn order_by_created_at(mut self) -> Self {
+        self.query = self.query.order(responses::created_at.desc());
+        self
+    }
+
+    pub async fn load(self) -> Result<Vec<Response>, Error> {
+        Ok(self.query.get_results(&db_conn()?)?)
+    }
+
+    pub async fn first(self) -> Result<Response, Error> {
+        Ok(self.query.first(&db_conn()?)?)
+    }
+}
+
+impl Response {
+    pub fn query() -> LazyQuery {
+        LazyQuery::new(responses::table.into_boxed())
+    }
+
+    pub async fn find(id: i64) -> Result<Self, Error> {
+        Ok(responses::table.find(id).first::<Self>(&db_conn()?)?)
+    }
+
+    pub async fn create(record: DirtyResponse) -> Result<Self, Error> {
+        use diesel::insert_into;
+
+        Ok(insert_into(responses::table)
+            .values(record)
+            .get_result(&db_conn()?)?)
+    }
+
+    pub async fn update(record: DirtyResponse, id: i64) -> Result<Self, Error> {
+        Ok(
+            diesel::update(responses::table.filter(responses::id.eq(id)))
+                .set(&record)
+                .get_result(&db_conn()?)?,
+        )
+    }
+
+    pub async fn delete(id: i64) -> Result<Self, Error> {
+        Ok(diesel::delete(responses::table.filter(responses::id.eq(id))).get_result(&db_conn()?)?)
+    }
+}

--- a/lib/store/src/schema.rs
+++ b/lib/store/src/schema.rs
@@ -12,6 +12,31 @@ table! {
 }
 
 table! {
+    requests (id) {
+        id -> Int8,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+        method -> Varchar,
+        uri -> Varchar,
+        headers -> Text,
+        body -> Nullable<Text>,
+        raw_message -> Nullable<Text>,
+    }
+}
+
+table! {
+    responses (id) {
+        id -> Int8,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+        code -> Int2,
+        headers -> Text,
+        body -> Nullable<Text>,
+        raw_message -> Nullable<Text>,
+    }
+}
+
+table! {
     transactions (id) {
         id -> Int8,
         created_at -> Timestamptz,
@@ -24,4 +49,4 @@ table! {
 
 joinable!(transactions -> dialogs (dialog_id));
 
-allow_tables_to_appear_in_same_query!(dialogs, transactions,);
+allow_tables_to_appear_in_same_query!(dialogs, requests, responses, transactions,);

--- a/lib/store/src/transaction.rs
+++ b/lib/store/src/transaction.rs
@@ -64,7 +64,7 @@ impl<'a> LazyQuery<'a> {
     }
 
     pub async fn load(self) -> Result<Vec<Transaction>, Error> {
-        Ok(self.query.get_results(&db_conn()?)?.into())
+        Ok(self.query.get_results(&db_conn()?)?)
     }
 
     pub async fn first(self) -> Result<Transaction, Error> {

--- a/migrations/2020-07-20-092949_transactions_and_dialogs/up.sql
+++ b/migrations/2020-07-20-092949_transactions_and_dialogs/up.sql
@@ -18,6 +18,6 @@ CREATE TABLE transactions(
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
   state VARCHAR(255) NOT NULL,
   branch_id VARCHAR NOT NULL,
-  dialog_id BIGINT NOT NULL REFERENCES dialogs(id)
+  dialog_id BIGINT NOT NULL REFERENCES dialogs(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
 SELECT diesel_manage_updated_at('transactions');

--- a/migrations/2020-07-22-215337_create_requests_and_responses/down.sql
+++ b/migrations/2020-07-22-215337_create_requests_and_responses/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE requests;
+DROP TABLE responses;

--- a/migrations/2020-07-22-215337_create_requests_and_responses/up.sql
+++ b/migrations/2020-07-22-215337_create_requests_and_responses/up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE requests(
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  method VARCHAR(255) NOT NULL,
+  uri VARCHAR NOT NULL,
+  headers TEXT NOT NULL,
+  body TEXT NULL,
+  raw_message TEXT NULL
+);
+SELECT diesel_manage_updated_at('requests');
+
+CREATE TABLE responses(
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  code SMALLINT NOT NULL,
+  headers TEXT NOT NULL,
+  body TEXT NULL,
+  raw_message TEXT NULL
+);
+SELECT diesel_manage_updated_at('responses');

--- a/notes.md
+++ b/notes.md
@@ -1,10 +1,12 @@
 # Notes
 
 #### To Do
-* Finish the convertion of Flow to DialogFlow
-* Finish the convertion of Dialog to Transaction (check states from the RFC)
-* Finsih the generation of the Response from the incoming Request
-* Finish the processor for the registration
+* ~~Finish the convertion of Flow to DialogFlow~~
+* ~~Finish the convertion of Dialog to Transaction (check states from the RFC)~~
+* ~~Finsih the generation of the Response from the incoming Request~~
+* ~~Finish the processor for the registration~~
+* Fix sip trace to log the whole message + the struct somehow
+* Look into traits
 
 
 Much later:


### PR DESCRIPTION
+ traces the request/response models
+ traces the raw incoming and outgoing requests/responses
+ also updates to latest stable libsip

At the moment it's a bit ugly and heavily underoptimize, probably in
the future we will embrace it a bit more with some extra love, for
instance a cool feature would be to be able to trace specific IP
addresses, dialogs/transactions, users etc....